### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BDGMacros
 
-Incredibly useful macro's that I use in all my xCode projects!
+Incredibly useful macro's that I use in all my Xcode projects!
 
 ## Installation using Cocoapods
 ```


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
